### PR TITLE
Content type compatible

### DIFF
--- a/src/http/Request.php
+++ b/src/http/Request.php
@@ -322,7 +322,7 @@ class Request extends Object implements ShouldBeRefreshed
         } else if ($contentType == 'multipart/form-data') {
             // noop
         } else {
-            throw new NotSupportedException("The content type: '$contentType' does not supported");
+            $parsedBody['body'] = $body;
         }
 
         return $parsedBody;


### PR DESCRIPTION
对除 json,x-www-form-urlencoded,form-data 之外的 content-type 进行了兼容的处理 统一放在 body中 主要是用于例如 微信支付回调使用xml的格式
