### PR TITLE
Added env file support

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -18,7 +18,8 @@
     "nikic/fast-route": "1.2.*",
     "monolog/monolog": "~1.0",
     "symfony/console": "^3.0",
-    "psy/psysh": "^0.7.2"
+    "psy/psysh": "^0.7.2",
+    "symfony/dotenv": "^3.3"
   },
   "require-dev": {
     "phpunit/phpunit": "~5.0"

--- a/src/console/BaseServer.php
+++ b/src/console/BaseServer.php
@@ -4,6 +4,8 @@ namespace blink\console;
 
 use blink\core\console\Command;
 use blink\core\InvalidValueException;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Dotenv\Dotenv;
 
 /**
  * Class BaseServerCommand
@@ -18,6 +20,15 @@ class BaseServer extends Command
      * @var bool
      */
     public $bootstrap = false;
+
+    protected function loadEnvFile(InputInterface $input)
+    {
+        $file = $input->getOption('env-file');
+
+        if ($file) {
+            (new Dotenv())->load($file);
+        }
+    }
 
     protected function getServerDefinition()
     {

--- a/src/console/ServerCommand.php
+++ b/src/console/ServerCommand.php
@@ -3,10 +3,10 @@
 namespace blink\console;
 
 use blink\core\InvalidParamException;
-use blink\core\InvalidValueException;
 use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
+use Symfony\Component\Console\Input\InputOption;
 
 /**
  * Class ServerCommand
@@ -21,6 +21,7 @@ class ServerCommand extends BaseServer
     protected function configure()
     {
         $this->addArgument('operation', InputArgument::REQUIRED, 'the operation: serve, start, reload, restart or stop');
+        $this->addOption('env-file', null, InputOption::VALUE_REQUIRED, 'The env file');
     }
 
     protected function execute(InputInterface $input, OutputInterface $output)
@@ -30,6 +31,8 @@ class ServerCommand extends BaseServer
         if (!in_array($operation, ['serve', 'start', 'reload', 'restart', 'stop'], true)) {
             throw new InvalidParamException('The <operation> argument is invalid');
         }
+
+        $this->loadEnvFile($input);
 
         return call_user_func([$this, 'handle' . $operation]);
     }

--- a/src/console/ServerRestartCommand.php
+++ b/src/console/ServerRestartCommand.php
@@ -4,6 +4,7 @@ namespace blink\console;
 
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
+use Symfony\Component\Console\Input\InputOption;
 
 /**
  * Class ServerRestartCommand
@@ -15,8 +16,15 @@ class ServerRestartCommand extends BaseServer
     public $name = 'server:restart';
     public $description = 'Restart a blink server';
 
+    protected function configure()
+    {
+        $this->addOption('env-file', null, InputOption::VALUE_REQUIRED, 'The env file');
+    }
+
     protected function execute(InputInterface $input, OutputInterface $output)
     {
+        $this->loadEnvFile($input);
+
         return $this->handleRestart();
     }
 }

--- a/src/console/ServerServeCommand.php
+++ b/src/console/ServerServeCommand.php
@@ -20,6 +20,7 @@ class ServerServeCommand extends BaseServer
     {
         $this->addOption('cli', null, InputOption::VALUE_NONE, "Serve requests using php's built-in web server");
         $this->addOption('live-reload', null, InputOption::VALUE_NONE, "Reload server on every requests, useful on development environment");
+        $this->addOption('env-file', null, InputOption::VALUE_REQUIRED, 'The env file');
     }
 
     protected function execute(InputInterface $input, OutputInterface $output)
@@ -30,6 +31,8 @@ class ServerServeCommand extends BaseServer
             $this->error('The Swoole extension is not installed, the PHP\'s built-in web server will be used');
             $cliMode = true;
         }
+
+        $this->loadEnvFile($input);
 
         if ($cliMode) {
             return $this->handleCliServe();

--- a/src/console/ServerStartCommand.php
+++ b/src/console/ServerStartCommand.php
@@ -3,6 +3,7 @@
 namespace blink\console;
 
 use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
 
 /**
@@ -15,8 +16,15 @@ class ServerStartCommand extends BaseServer
     public $name = 'server:start';
     public $description = 'Start a blink server as daemon';
 
+    protected function configure()
+    {
+        $this->addOption('env-file', null, InputOption::VALUE_REQUIRED, 'The env file');
+    }
+
     protected function execute(InputInterface $input, OutputInterface $output)
     {
+        $this->loadEnvFile($input);
+
         return $this->handleStart();
     }
 }

--- a/src/server/CgiServer.php
+++ b/src/server/CgiServer.php
@@ -9,6 +9,7 @@ namespace blink\server;
 
 use blink\http\File;
 use blink\http\Response;
+use Symfony\Component\Dotenv\Dotenv;
 
 /**
  * The CgiServer makes it possible to run Blink application upon php-fpm or Apache's mod_php.
@@ -19,6 +20,13 @@ use blink\http\Response;
  */
 class CgiServer extends Server
 {
+    public function init()
+    {
+        if ($file = getenv('ENV_FILE')) {
+            (new Dotenv())->load($file);
+        }
+    }
+
     protected function extractHeaders()
     {
         $headers = [];

--- a/src/server/CliServer.php
+++ b/src/server/CliServer.php
@@ -5,6 +5,7 @@ namespace blink\server;
 use blink\core\Application;
 use Symfony\Component\Console\Input\ArgvInput;
 use Symfony\Component\Console\Output\ConsoleOutput;
+use Symfony\Component\Dotenv\Dotenv;
 
 /**
  * Class CliServer
@@ -16,6 +17,14 @@ use Symfony\Component\Console\Output\ConsoleOutput;
  */
 class CliServer extends Server
 {
+
+    public function init()
+    {
+        if ($file = getenv('ENV_FILE')) {
+            (new Dotenv())->load($file);
+        }
+    }
+
     public function run()
     {
         $app = $this->startApp();

--- a/src/server/CliServer.php
+++ b/src/server/CliServer.php
@@ -17,7 +17,6 @@ use Symfony\Component\Dotenv\Dotenv;
  */
 class CliServer extends Server
 {
-
     public function init()
     {
         if ($file = getenv('ENV_FILE')) {


### PR DESCRIPTION
With env file support, it is possible to load environment variables into blink application with a file that specified by ENV_FILE environment variable, such as

```
ENV_FILE=path/to/env ./blink server:serve
```

or

```
./blink server:serve --env-file=path/to/env
```

It would be very useful to store sensitive information and environment-dependent settings.