### PR TITLE
Removing duplicate content length header

### DIFF
--- a/src/server/SwServer.php
+++ b/src/server/SwServer.php
@@ -224,7 +224,6 @@ class SwServer extends Server
                 $response->header($name, $value);
             }
         }
-        $response->header('Content-Length', strlen($content));
         foreach ($res->cookies as $cookie) {
             $response->header('Set-Cookie', $cookie->toString());
         }


### PR DESCRIPTION
On line 238 the call to the Response object's content() function will call prepare, which sets the Content-Length header, so this line that I am removing double sets that header.

Seems like most browsers do not care about it, but using this in a project that has health checks will fail the health check because of a malformed response header.

You can test this by just running it locally and running a curl -I and seeing the effects before and after this change.