### PR TITLE
Null data should not be encode

### DIFF
--- a/src/http/Response.php
+++ b/src/http/Response.php
@@ -169,7 +169,6 @@ class Response extends BaseObject implements ShouldBeRefreshed
     public function prepare()
     {
         if (!$this->prepared) {
-
             if ($this->data !== null) {
                 $this->content = is_string($this->data) ? $this->data : Json::encode($this->data);
                 if (!is_string($this->data) && !$this->headers->has('Content-Type')) {

--- a/src/http/Response.php
+++ b/src/http/Response.php
@@ -169,9 +169,12 @@ class Response extends BaseObject implements ShouldBeRefreshed
     public function prepare()
     {
         if (!$this->prepared) {
-            $this->content = is_string($this->data) ? $this->data : Json::encode($this->data);
-            if ($this->data !== null && !is_string($this->data) && !$this->headers->has('Content-Type')) {
-                $this->headers->set('Content-Type', 'application/json');
+
+            if ($this->data !== null) {
+                $this->content = is_string($this->data) ? $this->data : Json::encode($this->data);
+                if (!is_string($this->data) && !$this->headers->has('Content-Type')) {
+                    $this->headers->set('Content-Type', 'application/json');
+                }
             }
 
             $this->prepared = true;

--- a/src/server/CgiServer.php
+++ b/src/server/CgiServer.php
@@ -85,7 +85,7 @@ class CgiServer extends Server
             'method' => strtoupper($_SERVER['REQUEST_METHOD']),
             'path' => parse_url($requestUri, PHP_URL_PATH),
             'headers' => $this->extractHeaders(),
-            'queryString' => isset($_SERVER['QUERY_STRING']) ? $_SERVER['QUERY_STRING'] : '',
+            'queryString' => $_SERVER['QUERY_STRING'],
             'cookies' => $_COOKIE,
             'content' => file_get_contents('php://input'),
         ];

--- a/src/server/CgiServer.php
+++ b/src/server/CgiServer.php
@@ -85,7 +85,7 @@ class CgiServer extends Server
             'method' => strtoupper($_SERVER['REQUEST_METHOD']),
             'path' => parse_url($requestUri, PHP_URL_PATH),
             'headers' => $this->extractHeaders(),
-            'queryString' => $_SERVER['QUERY_STRING'],
+            'queryString' => isset($_SERVER['QUERY_STRING']) ? $_SERVER['QUERY_STRING'] : '',
             'cookies' => $_COOKIE,
             'content' => file_get_contents('php://input'),
         ];


### PR DESCRIPTION
The header `Content-Length` will not match the actual body length if `null` value was encoded and returned as the body.